### PR TITLE
Duration/Sidebar Hotfix 

### DIFF
--- a/neuvue_project/workspace/static/js/utils.js
+++ b/neuvue_project/workspace/static/js/utils.js
@@ -34,10 +34,10 @@ function sidemenu_content() {
 
     if (neuroglancer_window.style.width != "75%" ) {
       openSideMenu();
-      updateSideBar(1);
+      // updateSideBar(1);
     } else {
       closeSideMenu();
-      updateSideBar(0);
+      // updateSideBar(0);
     }
 
 } 


### PR DESCRIPTION
Devin and I discovered that when updated the sidebar session cookie, the duration for the current task that you were on would reset. This is because the sidebar cookie update would trigger a full GET request on the workspace page which resets all state variables for duration. 

We think a fix for this would be to make a dedicated API route for any cookie related updates and duration timing, this is still in the works though and we need a hotfix now to prevent data from being lost. 