### PR TITLE
add bottom row workspace hotkeys and table

### DIFF
--- a/neuvue_project/templates/workspace.html
+++ b/neuvue_project/templates/workspace.html
@@ -45,43 +45,45 @@
                     
                 </div>
             </div>
-            <div class="sideContentBox memo">
-                <div class="sideContentInfo memo">
-                    Pro Tip: Use Chrome and turn off toolbar in full screen! <br>
-                    Mac: CMD+SHIFT+F <br>
-                    PC: F11 <br>
-                    <table class="table table-dark">
-                        <thead>
-                          <tr>
-                            <th scope="col">Shortcut</th>
-                            <th scope="col">Mac</th>
-                            <th scope="col">PC</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <th scope="row">Save Checkpoint</th>
-                            <td>CTRL+OPT+S</td>
-                            <td></td>
-                          </tr>
-                          <tr>
-                            <th scope="row">Reload Checkpoint</th>
-                            <td>CTRL+OPT+R</td>
-                            <td></td>
-                          </tr>
-                          <tr>
-                            <th scope="row">Flag Task</th>
-                            <td>CTRL+OPT+F</td>
-                            <td></td>
-                          </tr>
-                          <tr>
-                            <th scope="row">Exit Task</th>
-                            <td>CTRL+OPT+E</td>
-                            <td></td>
-                          </tr>
-                        </tbody>
-                    </table>
-                </div>
+            
+            <! Shortcuts >
+            <div class="sideContentInfo">
+                <table class="table table-dark">
+                    <thead>
+                        <tr>
+                        <th scope="col">Shortcut</th>
+                        <th scope="col">Mac</th>
+                        <th scope="col">PC</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                        <th scope="row">Save Checkpoint</th>
+                        <td><kbd>CTRL</kbd>+<kbd>OPT</kbd>+<kbd>S</kbd></td>
+                        <td><kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>S</kbd></td>
+                        </tr>
+                        <tr>
+                        <th scope="row">Reload Checkpoint</th>
+                        <td><kbd>CTRL</kbd>+<kbd>OPT</kbd>+<kbd>R</kbd></td>
+                        <td><kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>R</kbd></td>
+                        </tr>
+                        <tr>
+                        <th scope="row">Flag Task</th>
+                        <td><kbd>CTRL</kbd>+<kbd>OPT</kbd>+<kbd>F</kbd></td>
+                        <td><kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd></td>
+                        </tr>
+                        <tr>
+                        <th scope="row">Exit Task</th>
+                        <td><kbd>CTRL</kbd>+<kbd>OPT</kbd>+<kbd>E</kbd></td>
+                        <td><kbd>ALT</kbd>+<kbd>SHIFT</kbd>+<kbd>E</kbd></td>
+                        </tr>
+                        <tr>
+                        <th scope="row">Full Screen (Chrome)</th>
+                        <td><kbd>CMD</kbd>+<kbd>SHIFT</kbd>+<kbd>F</kbd></td>
+                        <td><kbd>F11</kbd></td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
         </div>
     </div> 


### PR DESCRIPTION
Added hotkeys to bottom row workspace buttons and a table to explain them on mac. Need a windows user to test out the hotkeys! Wasn't sure if we should have hotkeys for all buttons?
![workspace-hotkeys](https://user-images.githubusercontent.com/50876892/146413022-e0a54daa-e934-4eed-ad0e-28805b6b7c58.png)

