### PR TITLE
Intertask page

### DIFF
--- a/neuvue_project/workspace/views.py
+++ b/neuvue_project/workspace/views.py
@@ -62,7 +62,7 @@ class WorkspaceView(LoginRequiredMixin, View):
 
         else:
 
-            if task_df['status'] == 'closed':
+            if task_df['status'] == 'pending':
                 self.client.patch_task(task_df["_id"], status="open")
             
             # Update Context


### PR DESCRIPTION
From task page- clicking "Start Proofreading" sends you to a task (bypasses intertask page). When no more tasks in that namespace are available it will route to landing page with "No Pending Tasks" and "Exit Workspace" buttons.