### PR TITLE
remove start button page code and update intertask splash page

### DIFF
--- a/neuvue_project/templates/workspace.html
+++ b/neuvue_project/templates/workspace.html
@@ -263,23 +263,12 @@
                     {% else %}
                     <! In-between Tasks >
                     <div class="interTaskBox">
-                        {%if tasks_available %}
-                        <button type="button" class="mainButton submit duo" id="btnStart" onclick="loadingSpinner('start_new_task')">
-                            <div id = 'start_new_task'>
-                                Start New  Task
-                            </div>
-                        </button>
-
-                        {% else %}
-                        <button type="button" class="mainButton submit duo" disabled >
-                            No Pending Tasks
-                        </button> 
-                        
-                        {% endif%}
-                        
+                        <div class="interTaskTitle">
+                            {{display_name}} Tasks Complete
+                        </div>
                         <button type="button" class="mainButton flag duo" onclick= "document.location='{% url 'tasks' %}';loadingSpinner('exit_workspace')">
                             <div id = 'exit_workspace'>
-                                Exit Workspace
+                                Return to Task page
                             </div>
                         </button>
                         {% endif %}

--- a/neuvue_project/workspace/static/css/workspace.css
+++ b/neuvue_project/workspace/static/css/workspace.css
@@ -813,6 +813,24 @@ background: transparent;
   transition: 0s;
 }
 
+.interTaskTitle {
+  font-family: var(--header-font);
+  color: var(--primary-accent);
+  border-radius: 2px;
+  font-size: 1.8vh;
+  z-index: 10;
+  padding: 1%;
+  flex-grow: 2;
+  text-align: center;
+  align-items: left;
+  text-decoration: none;
+  transition: 0s;
+  background-color: var(--background);
+  /*position: sticky;*/
+  top: 0;
+
+}
+
 
 .clipboard {
   color: var(--primary-accent);


### PR DESCRIPTION
Intertask page has been updated to look like below. Displays the namespace above the "back to task page" button
![Splashpage](https://user-images.githubusercontent.com/50876892/150205779-379d3731-3217-4623-a8bd-d5afbf0bf6a6.png)
