### PR TITLE
add hidden formatted column friendly for excel users!

### DIFF
--- a/neuvue_project/templates/dashboard.html
+++ b/neuvue_project/templates/dashboard.html
@@ -327,6 +327,7 @@
                         <th scope="col" style="padding-left: 10px"> <input type="checkbox" name="selectAll" class="taskCheckbox"></th>
                         <th scope="col">Task ID</th>
                         <th scope="col">Segment ID</th>
+                        <th scope="col">Segment ID: formatted</th>
                         <th scope="col">Status</th>
                         <th scope="col">Priority</th>
                         <th scope="col">Created</th>
@@ -342,6 +343,7 @@
                         <th scope="row"><input type="checkbox" form="taskPatchForm" name="selected_tasks" id="select_{{taskrow.task_id}}" value={{taskrow.task_id}} class="taskCheckbox"></th>
                         <th scope="row"><a href="{% url 'inspect' taskrow.task_id %}">{{taskrow.task_id}}</a></th>
                         <td>{{taskrow.seg_id}}</td>
+                        <td>#: {{taskrow.seg_id}}</td>
                         <td>{{taskrow.status}}</td>
                         <td>{{taskrow.priority}}</td>
                         <td>{{taskrow.created}}</td>
@@ -361,13 +363,19 @@
                     <table id='hiddenUserTable' class="table table-striped table-hover">${tableContents}</table>  
                 `);
                 $('#userModalBody').html(`
-                    <table id='userTable' class="table table-striped table-hover">${tableContents}</table>  
+                    <table id='userTable' class="table table-striped table-hover" style="width:100%">${tableContents}</table>  
                 `);
                 $('#userTable').DataTable({
-                    "columnDefs":[{
+                    "columnDefs":[
+                        {
                         "targets": 0,
                         "orderable": false
-                    }]
+                        },
+                        {
+                        "targets":3,
+                        "visible":false
+                        }
+                    ]
                 });
 
                 $('input[name=selectAll]').change(function(){

--- a/neuvue_project/templates/synapse.html
+++ b/neuvue_project/templates/synapse.html
@@ -98,6 +98,7 @@
                     <thead>
                       <tr>
                         <th scope="col">Root ID</th>
+                        <th scope="col">Root ID: formatted</th>
                         <th scope="col">Number of Presynaptic Connections</th>
                         <th scope="col">Number of Postsynaptic Connections</th>
                       </tr>
@@ -106,6 +107,7 @@
                       {% for root, stats in synapse_stats.items %}
                         <tr>
                           <td>{{root}}</td>
+                          <td>#: {{root}}</td>
                           <td>{{stats.num_pre}}</td>
                           <td>{{stats.num_post}}</td>
                         </tr>


### PR DESCRIPTION
Tables on website are unchanged:
![web_preview](https://user-images.githubusercontent.com/46499982/164462750-52ef41f0-d9fb-4bd5-bd96-280a41e7a2f3.png)
But hidden column has been added for seg_ids and root_ids for csv export so that automatic formatting occurs in excel
![download_csv](https://user-images.githubusercontent.com/46499982/164462748-2d78408f-5b35-4b70-936e-429a199f02b5.png)
