### PR TITLE
Update a few functions to remove command line warnings

### DIFF
--- a/neuvue_project/workspace/analytics.py
+++ b/neuvue_project/workspace/analytics.py
@@ -20,7 +20,7 @@ def is_lastweek(timestamp):
     """
     eastern = timezone('US/Eastern')
     
-    dt = timestamp.to_pydatetime()
+    dt = timestamp.to_pydatetime(warn=False)   # do not warn if nanoseconds are nonzero
     now = eastern.localize(datetime.now())
     weekago = now - timedelta(days=7)
     
@@ -32,13 +32,15 @@ def get_sum_time(table):
     return hours
     
 def get_rate(table):
-    mean =  np.array([x['duration'] for x in table]).mean()
- 
-    if np.isnan(mean):
-        return 0
-    else:
+
+    durations = np.array([x['duration'] for x in table])
+
+    if len(durations) > 0:
+        mean =  durations.mean()
         minutes = round(mean/(60))
         return minutes
+    else:
+        return 0
 
 def user_stats(table):
     # look at weekly stats

--- a/neuvue_project/workspace/utils.py
+++ b/neuvue_project/workspace/utils.py
@@ -36,7 +36,7 @@ def utc_to_eastern(time_value):
     try:
         utc = pytz.UTC
         eastern = timezone('US/Eastern')
-        date_time = time_value.to_pydatetime()
+        date_time = time_value.to_pydatetime(warn=False)  # do not warn if nanoseconds are nonzero
         date_time = utc.localize(time_value)
         return date_time.astimezone(eastern)
     except:


### PR DESCRIPTION
I was getting two very repetitive command line warnings when loading the `/tasks` page:

`/neuvue-app/neuvue_project/workspace/views.py:478: UserWarning: Discarding nonzero nanoseconds in conversion`
`/neuvue-app/neuvue_project/workspace/analytics.py:36: RuntimeWarning: Mean of empty slice.`

I made the changes that would remove them. Also checked other pages and didn't see any warnings, but if you know of any I'm happy to amend the pull request. Lmk if these changes are acceptable.