### PR TITLE
Assign all users in a group to a certain expertise level for a namespace

### DIFF
--- a/neuvue_project/workspace/admin.py
+++ b/neuvue_project/workspace/admin.py
@@ -48,7 +48,7 @@ INTERMEDIATE = "intermediate"
 EXPERT = "expert"
 
 class SetExpertiseLevelForNamespaceForm(admin.helpers.ActionForm):
-    namespace = forms.ModelChoiceField(Namespace.objects, label=False, empty_label="Namespace", widget=forms.Select(attrs={"class": "mb-1"}))
+    namespace = forms.ModelChoiceField(Namespace.objects, label=False, empty_label="Namespace", widget=forms.Select(attrs={"class": "mb-1"}), required=False)
 
 class CustomGroupAdmin(GroupAdmin):
     action_form = SetExpertiseLevelForNamespaceForm
@@ -64,7 +64,14 @@ class CustomGroupAdmin(GroupAdmin):
         self.set_expertise_level_for_namespace(EXPERT, request, queryset)
     
     def set_expertise_level_for_namespace(self, level, request, queryset):
-        namespace = Namespace.objects.get(namespace = request.POST['namespace'])
+
+        namespace = ""
+        try:
+            namespace = Namespace.objects.get(namespace = request.POST['namespace'])
+        except:
+            messages.error(request, "Please select a namespace.")
+            return
+
         for group in queryset:
             users = Group.objects.get(name=group).user_set.all()
             for user in users:


### PR DESCRIPTION
Suggested test cases:
* edit a group's expertise level and make sure it is correct on several users' pages
* edit multiple groups' expertise levels at the same time
* test on your own user by self-assigning tasks and making sure they come from the correct unassigned bucket

Before:
![image](https://user-images.githubusercontent.com/24723182/195908189-8f343086-3554-46de-9530-8c67ea677b1b.png)

After:
![image](https://user-images.githubusercontent.com/24723182/195908261-550418cb-483c-4cab-9aed-03b7e07623b5.png)

User page:
![image](https://user-images.githubusercontent.com/24723182/195908354-49815687-eeab-4cb4-9e9d-df3cd40634ef.png)
