### PR TITLE
html formatted instructions

### DIFF
--- a/neuvue_project/dashboard/templatetags/inclusion_tags.py
+++ b/neuvue_project/dashboard/templatetags/inclusion_tags.py
@@ -43,3 +43,9 @@ def confirm_selected_segments_modal(number_of_selected_segments_expected):
 @register.inclusion_tag('modals/distribute_task_modal.html')
 def distribute_task_modal():
     return {}
+
+@register.inclusion_tag('reusable_components/instructions.html')
+def processed_instructions(instructions):
+    return {
+        "instructions": instructions
+    }

--- a/neuvue_project/templates/inspect.html
+++ b/neuvue_project/templates/inspect.html
@@ -36,20 +36,7 @@
   <div id="neuVue-sidecontent" class="sidecontent">
       
       <! Instructions >
-      <div id = "instruction-container" class ="sideContentBox" style="max-height:30%;">
-        <div class="sideContentTitle">
-            Instructions
-        </div>
-        <div class="sideContentInfo">
-            {{ instructions.prompt | linebreaksbr }}
-            {% if instructions.media %} 
-                <br>
-                <div style="display:flex; justify-content: center; margin:1vh 0vh;">
-                    <img src={{  instructions.media }} class="instruction-image" onclick="window.open('{{  instructions.media }}')">
-                </div>
-            {% endif %}
-        </div>
-      </div>
+      {% processed_instructions instructions %}
       
       <! Task Information >
       <div id = "instruction-container" class ="sideContentBox" style="max-height:70%;">

--- a/neuvue_project/templates/reusable_components/instructions.html
+++ b/neuvue_project/templates/reusable_components/instructions.html
@@ -1,0 +1,22 @@
+<div id = "instruction-container" class ="sideContentBox" style="max-height:30%;">
+    <div class="sideContentTitle">
+        Instructions
+    </div>
+    <div class="sideContentInfo">
+        <div class="prompt">{{ instructions.prompt | safe | linebreaksbr }}</div>
+                        
+        {% if instructions.media %} 
+            <br>
+            <div style="display:flex; justify-content: center; margin:1vh 0vh;">
+                <img src={{  instructions.media }} class="instruction-image" onclick="window.open('{{  instructions.media }}')">
+            </div>
+        {% endif %}
+    </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+<script type="text/javascript">
+    // all hyperlinks open in new tab 
+    // $("#sideContentInfo a").attr({"target": "_blank", "rel":"noopener noreferrer"});
+    $("div.prompt a").attr({"target": "_blank", "rel":"noopener noreferrer"});
+</script>

--- a/neuvue_project/templates/workspace.html
+++ b/neuvue_project/templates/workspace.html
@@ -20,20 +20,8 @@
         <div id="neuVue-sidecontent" class="sidecontent">
             
             <! Instructions >
-            <div id = "instruction-container" class ="sideContentBox" style="max-height:30%;">
-                <div class="sideContentTitle">
-                    Instructions
-                </div>
-                <div class="sideContentInfo">
-                    {{ instructions.prompt | linebreaksbr }}
-                    {% if instructions.media %} 
-                        <br>
-                        <div style="display:flex; justify-content: center; margin:1vh 0vh;">
-                            <img src={{  instructions.media }} class="instruction-image" onclick="window.open('{{  instructions.media }}')">
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
+            {% processed_instructions instructions %}
+            
             <! Task Notes >
             <div id="tag-container" class = "sideContentBox" style="max-height:35%;">
                 <div class="sideContentTitle">


### PR DESCRIPTION
Issue #370 
Instruction prompts formatted using html will now be rendered appropriately.

i.e. the following prompt would be formatted as such:
![instructionsRaw](https://user-images.githubusercontent.com/46499982/205365424-5ca8b69f-f64d-4867-8310-089cb8c00c97.png)

![instructionFormatting](https://user-images.githubusercontent.com/46499982/205364821-47264830-8f7d-4fef-827b-d2e6a14f2c0d.png)

All hyperlinks in the instructions automatically open in a new tab as well.