### PR TITLE
Remove requirement for python 3.9 to be used in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,3 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-        language_version: python3.9


### PR DESCRIPTION
AFAIK this is entirely not needed and in general just complicates use of pre-commit on systems which no longer (for years) have 3.9 readily available