### PR TITLE
Support public tasks

### DIFF
--- a/neuvue_project/dashboard/views.py
+++ b/neuvue_project/dashboard/views.py
@@ -63,6 +63,7 @@ class DashboardView(View, LoginRequiredMixin):
         display_name = request.POST.get("namespace")
         group = request.POST.get("group")
         username = request.POST.get("username")
+        shortcut = request.POST.get("shortcut")
 
         if display_name and group:
             namespace = Namespaces.objects.get(display_name=display_name).namespace
@@ -71,6 +72,11 @@ class DashboardView(View, LoginRequiredMixin):
             )
         elif username:
             return redirect(reverse("dashboard", kwargs={"username": username}))
+        elif shortcut:
+            if shortcut == "View all tasks assigned to public username":
+                return redirect(reverse("dashboard", kwargs={"username": "public"}))
+            else:
+                return redirect(reverse("dashboard"))
         else:
             # as long as all html form fields contain required="true" this case should not be reached
             return redirect(reverse("dashboard"))

--- a/neuvue_project/templates/about.html
+++ b/neuvue_project/templates/about.html
@@ -82,7 +82,7 @@
         <h2 class="pt-5 pb-3"> Contact Us </h2>
 
         <p>
-            We'd love to hear from you! Reach out at <a class="text-secondary-color-activated" href="mailto:info@neuvue.io">info@bossdb.org</a> with questions or if you are interested in collaborating with us.
+            We'd love to hear from you! Reach out at <a class="text-secondary-color-activated" href="mailto:info@bossdb.org">info@bossdb.org</a> with questions or if you are interested in collaborating with us.
         </p>
 
     </div>

--- a/neuvue_project/templates/admin_dashboard/dashboard.html
+++ b/neuvue_project/templates/admin_dashboard/dashboard.html
@@ -21,6 +21,9 @@
             <li class="nav-item margin-right-05">
                 <a class="nav-link" href="#username" data-bs-toggle="tab">Username</a>
             </li>
+            <li class="nav-item margin-right-05">
+                <a class="nav-link" href="#shortcuts" data-bs-toggle="tab">Shortcuts</a>
+            </li>
         </ul>
 
         <div class="tab-content">
@@ -84,6 +87,30 @@
                     </div>
                 </form>
             </div>
+
+            <div class="tab-pane fade" id="shortcuts">
+                <form action="" method="post" onSubmit="triggerLoadingSpinner('submit-spinner-tab3')">
+                {% csrf_token %}
+                    <div class="form-group my-3">
+                        <label class="text-white" for="userSelect">Shortcuts</label>
+                        <select name="shortcut" class="form-select" id="shortcutSelect" placeholder="Select one" required="true">
+                            <option value="" selected disabled>Please select</option>
+                            <option>View all tasks assigned to public username</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group d-flex my-4">
+                        <input type="submit" class="btn btn-primary" value="Submit">
+                        <div id="submit-spinner-tab3" class="text-white ms-3 mt-2"></div>
+
+                        {% if error %}
+                        <small id="errormessage" class="form-text text-danger"> {{error}} </small>
+                        {% endif %}
+
+                    </div>
+                </form>
+            </div>
+
         </div>
     </div>
 </div>
@@ -101,6 +128,11 @@
     window.addEventListener('pageshow', function(e) {
         if (document.getElementById('submit-spinner-tab2') !== null) {
             removeLoadingSpinner('submit-spinner-tab2');
+        }
+    })
+    window.addEventListener('pageshow', function(e) {
+        if (document.getElementById('submit-spinner-tab3') !== null) {
+            removeLoadingSpinner('submit-spinner-tab3');
         }
     })
 

--- a/neuvue_project/templates/base.html
+++ b/neuvue_project/templates/base.html
@@ -68,13 +68,14 @@
                   <li> <a class="dropdown-item" href="{% url "nuclei" %}">Nuclei Viewer</a> </li>
               </ul>
             </li>
-            <li class="nav-item">
-              <a class="btn btn-outline-success" href="{% url "tasks" %}">My Tasks</a>
-            </li>
 
             {% endif%}
 
             {% if request.user.is_authenticated %}
+
+            <li class="nav-item">
+              <a class="btn btn-outline-success" href="{% url "tasks" %}">My Tasks</a>
+            </li>
 
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/neuvue_project/templates/tasks.html
+++ b/neuvue_project/templates/tasks.html
@@ -181,6 +181,12 @@
                     </button>
                 </div>
             </div>
+        
+            {% if not data.settings.is_authorized %}
+            <h5 class="text-light text-center">
+                Have questions or are interested in collaborating? Email us at <a class="text-pink" href="mailto:neuvue@bossdb.org">neuvue@bossdb.org</a>.
+            </h5>
+            {% endif %}
 
         </div>
 

--- a/neuvue_project/templates/workspace.html
+++ b/neuvue_project/templates/workspace.html
@@ -377,7 +377,7 @@
 
     const tracked_new_operations = new Set();
     function updateTrackedOperations(current_operation_ids){
-        if (current_operation_ids.length > 0) {
+        if (current_operation_ids && current_operation_ids.length > 0) {
             for (const [idx, ele] of current_operation_ids.entries()){
                 if (!tracked_new_operations.has(ele)){
                     tracked_new_operations.add(ele);
@@ -407,6 +407,7 @@
 
         $('<input>').attr('type', 'hidden').attr('name', 'button').attr('value', value).appendTo(form);
         $('<input>').attr('type', 'hidden').attr('name', 'duration').attr('value', duration).appendTo(form);
+        $('<input>').attr('type', 'hidden').attr('name', 'taskId').attr('value', "{{task_id}}").appendTo(form);
         $(form).submit();
 
         {% elif ng_host == "spelunker" %}
@@ -415,6 +416,7 @@
         $('<input>').attr('type', 'hidden').attr('name', 'ngState').attr('value', state).appendTo(form);
         $('<input>').attr('type', 'hidden').attr('name', 'button').attr('value', value).appendTo(form);
         $('<input>').attr('type', 'hidden').attr('name', 'duration').attr('value', duration).appendTo(form);
+        $('<input>').attr('type', 'hidden').attr('name', 'taskId').attr('value', "{{task_id}}").appendTo(form);
 
         $(form).submit();
 
@@ -433,6 +435,7 @@
             $('<input>').attr('type', 'hidden').attr('name', 'button').attr('value', value).appendTo(form);
             $('<input>').attr('type', 'hidden').attr('name', 'duration').attr('value', duration).appendTo(form);
             $('<input>').attr('type', 'hidden').attr('name', 'ngDifferStack').attr('value', ng_differ_stack).appendTo(form);
+            $('<input>').attr('type', 'hidden').attr('name', 'taskId').attr('value', "{{task_id}}").appendTo(form);
 
             {% if track_selected_segments %}
             const selected_segments = getSelectedSegments(viewer.state);

--- a/neuvue_project/workspace/static/css/tasks.css
+++ b/neuvue_project/workspace/static/css/tasks.css
@@ -337,3 +337,7 @@ tbody.pending >:nth-child(2) {
 .bg-pink {
   background-color: #d63384;
 }
+
+.text-pink {
+  color: #d63384;
+}

--- a/neuvue_project/workspace/static/workspace/index.html
+++ b/neuvue_project/workspace/static/workspace/index.html
@@ -29,7 +29,7 @@
           (storage && storage.length !== 0);
 
         if (!outOfSpace) {
-          alert('Local Storage has been disabled, please renable it in Chrome');
+          alert('Local Storage has been disabled, please re-enable it in Chrome');
         }
       }
     }

--- a/neuvue_project/workspace/views/task.py
+++ b/neuvue_project/workspace/views/task.py
@@ -149,7 +149,10 @@ class TaskView(LoginRequiredMixin, View):
         request.session["session_task_count"] = 0
 
         # create settings and context dicts
-        settings_dict = {"SANDBOX_ID": settings.SANDBOX_ID}
+        settings_dict = {
+            "SANDBOX_ID": settings.SANDBOX_ID,
+            "is_authorized": is_authorized(request.user)
+        }
         daily_changelog, full_changelog = create_stats_table(
             pending_tasks, closed_tasks
         )

--- a/neuvue_project/workspace/views/task.py
+++ b/neuvue_project/workspace/views/task.py
@@ -78,12 +78,15 @@ class TaskView(LoginRequiredMixin, View):
             else:
                 context[namespace]["can_unassign_tasks"] = True
 
-        if not is_authorized(request.user):
-            logging.warning(f"Unauthorized requests from {request.user}.")
-            return redirect(reverse("index"))
+        if is_authorized(request.user):
+            assignee = str(request.user)
+        else:
+            assignee = "public"
+            # logging.warning(f"Unauthorized requests from {request.user}.")
+            # return redirect(reverse("index"))
 
         pending_tasks = client.get_tasks(
-            sieve={"status": ["open", "pending"], "assignee": str(request.user)},
+            sieve={"status": ["open", "pending"], "assignee": assignee},
             select=[
                 "seg_id",
                 "namespace",

--- a/neuvue_project/workspace/views/tools.py
+++ b/neuvue_project/workspace/views/tools.py
@@ -40,9 +40,9 @@ class InspectTaskView(View):
             "num_edits": 0,
         }
 
-        if not is_authorized(request.user):
-            logging.warning(f"Unauthorized requests from {request.user}.")
-            return redirect(reverse("index"))
+        # if not is_authorized(request.user):
+        #     logging.warning(f"Unauthorized requests from {request.user}.")
+        #     return redirect(reverse("index"))
 
         if task_id is None:
             return render(request, "inspect.html", context)

--- a/neuvue_project/workspace/views/workspace.py
+++ b/neuvue_project/workspace/views/workspace.py
@@ -102,9 +102,12 @@ class WorkspaceView(LoginRequiredMixin, View):
         else:
             context["number_of_selected_segments_expected"] = None
 
-        if not is_authorized(request.user):
-            logging.warning(f"Unauthorized requests from {request.user}.")
-            return redirect(reverse("index"))
+        if is_authorized(request.user):
+            assignee = str(request.user)
+        else:
+            assignee = "public"
+            # logging.warning(f"Unauthorized requests from {request.user}.")
+            # return redirect(reverse("index"))
 
         if namespace is None:
             logging.debug("No namespace query provided.")
@@ -113,7 +116,7 @@ class WorkspaceView(LoginRequiredMixin, View):
 
         # Get the next task. If its open already display immediately.
         # TODO: Save current task to session.
-        task_df = client.get_next_task(str(request.user), namespace)
+        task_df = client.get_next_task(assignee, namespace)
 
         if not task_df:
             context["tasks_available"] = False
@@ -283,6 +286,7 @@ class WorkspaceView(LoginRequiredMixin, View):
                 ng_state=ng_state,
                 tags=tags,
                 metadata=metadata,
+                assignee=str(request.user)
             )
             # Add new differ stack entry
             if ng_differ_stack != []:
@@ -300,6 +304,7 @@ class WorkspaceView(LoginRequiredMixin, View):
                 ng_state=ng_state,
                 metadata=metadata,
                 tags=tags,
+                assignee=str(request.user)
             )
             # Add new differ stack entry
             if ng_differ_stack != []:

--- a/neuvue_project/workspace/views/workspace.py
+++ b/neuvue_project/workspace/views/workspace.py
@@ -232,7 +232,7 @@ class WorkspaceView(LoginRequiredMixin, View):
         namespace_obj = Namespace.objects.get(namespace=namespace)
 
         # Current task that is opened in this namespace.
-        task_df = client.get_next_task(str(request.user), namespace)
+        task_df = client.get_task(request.POST.get("taskId"))
 
         # All form submissions include button name and ng state
         button = request.POST.get("button")


### PR DESCRIPTION
Note that I define a public task as a task available to an authenticated, unauthorized user. Authenticated means they've logged in with a Google account, unauthorized means that an admin user has not yet moved this user to the AuthorizedUsers group in the Django console.
* Add 40 tasks to a namespace called Public Tasks Test (WIP). Assign all tasks to user "public" at creation.
* Allow public users access to the task page, workspace page, and inspect task page.
* Allow public users access to open & pending tasks which are assigned to user "public". Hide these tasks from authorized users.
* Allow public users access to closed tasks assigned to themselves.
* When task is submitted, use the task ID instead of `get_next_task()`
* Reassign public tasks to submitting username on close. (Still need to think through security implications of this)
* Add a new tab called Shortcuts to the dashboard page and add the ability to view all tasks assigned to user "public" through this new tab. This is helpful because no google account corresponds to the "public" assignee. We can add other shortcuts in the future if we want.
* Add contact email to task page for unauthorized user
* Fix a bug associated with choosing NO to tracking operation IDs when creating a namespace
* Fix a spellcheck bug for the bot