### PR TITLE
Fix: User menu getting cropped on some systems

### DIFF
--- a/neuvue_project/templates/base.html
+++ b/neuvue_project/templates/base.html
@@ -81,7 +81,7 @@
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 <b> {{user.username}} </b>
               </a>
-              <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDropdown">
+              <ul class="dropdown-menu dropdown-menu-dark dropdown-menu-end" aria-labelledby="navbarDropdown">
                 <li><a class="dropdown-item" href="{% url "preferences" %}" >Preferences</a></li>
                 <li><a class="dropdown-item" href="{% url "logout" %}">Sign Out</a></li>
               </ul>


### PR DESCRIPTION
From fresh local-devstack:
![image](https://github.com/user-attachments/assets/1f322b30-ff8f-429a-a1c9-8036f0c56ef4)

This branch adjusts the alignment of the dropdown to prevent this:
![image](https://github.com/user-attachments/assets/aa51f6d0-1097-4373-bb12-65e53e9917cc)

