### PR TITLE
Fix Double Scroll Bar

### DIFF
--- a/neuvue_project/templates/base.html
+++ b/neuvue_project/templates/base.html
@@ -23,7 +23,7 @@
     <link href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css" rel="stylesheet" type="text/css" />
   </head>
 
-  <body style="background-color: var(--background);">
+  <body style="background-color: var(--background); height: 100%; overflow: hidden;">
     <! Navigation Bar >
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">


### PR DESCRIPTION
Closes #433 , tested on a couple pages and seems to work on a variety of window sizes and aspect ratios. Could possibly break reports >1 total page height though. 