### PR TITLE
Updates to "About" and "Getting Started" placement

### DIFF
--- a/neuvue_project/templates/about.html
+++ b/neuvue_project/templates/about.html
@@ -48,7 +48,7 @@
         <p>
             Sample tasks are available for all users with an account. Simply log-in and tasks will automatically be added for you to explore!
             Additional information and FAQ can be found by visiting our page <a class="text-secondary-color-activated"
-            href="{% url 'getting-started' %}">Getting Started</a> page.
+            href="{% url 'getting-started' %}">Getting Started</a>.
         </p>
 
         <h2 class="pt-5 pb-3"> Publications </h2>

--- a/neuvue_project/templates/about.html
+++ b/neuvue_project/templates/about.html
@@ -43,6 +43,14 @@
             <a class="text-secondary-color-activated" href="https://www.iarpa.gov/research-programs/microns">Learn more about MICrONS.</a>
         </p>
 
+        <h1 class="pt-5 pb-3" aria-level="1"> Explore NeuVue tasks now </h1>
+
+        <p>
+            Sample tasks are available for all users with an account. Simply log-in and tasks will automatically be added for you to explore!
+            Additional information and FAQ can be found by visiting our page <a class="text-secondary-color-activated"
+            href="{% url 'getting-started' %}">Getting Started</a> page.
+        </p>
+
         <h2 class="pt-5 pb-3"> Publications </h2>
 
         <p>

--- a/neuvue_project/templates/base.html
+++ b/neuvue_project/templates/base.html
@@ -52,7 +52,9 @@
             {% endif%}
 
             {% if request.user|in_group:"AuthorizedUsers"%}
-
+            <li class="nav-item">
+              <a class="nav-link", href="{% url "about" %}"> About</a>
+            </li>
             <li class="nav-item">
               <a class="nav-link" href="{% url "getting-started" %}">Getting Started</a>
             </li>
@@ -76,7 +78,6 @@
             <li class="nav-item">
               <a class="btn btn-outline-success" href="{% url "tasks" %}">My Tasks</a>
             </li>
-
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 <b> {{user.username}} </b>
@@ -91,6 +92,9 @@
 
             <li class="nav-item">
               <a class="nav-link", href="{% url "about" %}"> About</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{% url "getting-started" %}">Getting Started</a>
             </li>
             <li class="nav-item">
               <a class="btn btn-outline-info" href="{% provider_login_url 'google' %}">Sign In</a>

--- a/neuvue_project/templates/index.html
+++ b/neuvue_project/templates/index.html
@@ -9,16 +9,20 @@
   <div class="container-fluid inherit-height">
     <div class="row inherit-height">
       <div class="col-md-6 d-flex justify-content-center align-items-center">
-        <div class="d-flex justify-content-center">
-          <div class="title-container">
-            <h1 class="index-title-text mt-4 my-1">Welcome to NeuVue</h1>
+        <div class="title-container text-center">
+          <h1 class="index-title-text mt-4 my-1">Welcome to NeuVue</h1>
+          <div class="flex-column mt-3 mx-auto" style="width: 200px;">
           {% if user.is_authenticated %}
             <div class="d-flex justify-content-center">
-              <span class="index-title-sub-text">You are logged in as <b>{{ user.username }}. </b> </p>
+              <span class="index-title-sub-text">You are logged in as <b>{{ user.username }}</b>.</span>
             </div>
           {% else %}
-            <a class="index-title-sub-text d-flex justify-content-center" href="{% provider_login_url 'google' %}" ><img width="200"src="static/images/google.png" alt="Sign in with Google"></a>
+            <a class="index-title-sub-text d-flex justify-content-center mb-2" href="{% provider_login_url 'google' %}">
+              <img width="200" src="static/images/google.png" alt="Sign in with Google">
+            </a>
           {% endif %}
+            <a class="btn btn-info mb-2 w-100" style="font-size: 2vh; color: var(--primary-accent);" href="{% url 'about' %}">About</a>
+            <a class="btn btn-info w-100" style="font-size: 2vh; color: var(--primary-accent);" href="{% url 'getting-started' %}">Getting Started</a>
           </div>
         </div>
       </div>

--- a/neuvue_project/workspace/static/getting_started.md
+++ b/neuvue_project/workspace/static/getting_started.md
@@ -4,6 +4,11 @@ This page contains resources and documentation to help you get started proofread
 
 ## Accessing the Proofreading Interface
 
+### Explore NeuVue tasks now
+
+Sample tasks are available for all users with an account. Simply log-in and tasks will automatically be added for you to explore!
+Additional information and FAQ can be found by visiting our page <a class="text-secondary-color-activated" href="{% url 'getting-started' %}">Getting Started</a> page.
+
 ### Home Page
 
 <img src="https://i.imgur.com/BbuuTWg.png" alt="Home Page" width="800"/>
@@ -59,7 +64,7 @@ From this point you can begin proofreading by deciding on which task types you w
 
 <img src="https://i.imgur.com/CEsxB92.jpg" alt="Workspace Page" width="800"/>
 
-The workspace page provides all the tools necessary to complete a proofreading task. The page is an extension of [Neuroglancer](https://github.com/google/neuroglancer), the primary tool for viewing, annotating, and editing the volumetric data we use for proofreading.
+The workspace page provides all the tools necessary to complete a proofreading task. The page is an extension of <a href="https://github.com/google/neuroglancer" target="_blank">Neuroglancer</a>, the primary tool for viewing, annotating, and editing the volumetric data we use for proofreading.
 
 The workspace page consists an embedded neuroglancer window, task-specific buttons, and a toggle-able side panel that contains information about the current task as well as additional features. Once the user navigates to the workspace, a task from the queue will automatically be loaded in and set to status *open*. If a task is already open for the selected task type, that task will be re-opened.
 
@@ -87,9 +92,9 @@ Some forced choice tasks have both decision buttons and a "Submit" button. In th
 ### Neuroglancer (WIP)
 Here is a great instructional video on how to operate Neuroglancer for basic navigation and data exploration.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/TwBTyWWnbxc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/TwBTyWWnbxc" title="YouTube video playerr" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-[This cheatsheet](https://docs.google.com/document/d/1eypqJ9iI1GlWSPMTZQo9oDCLEahye6oYo_CuhS_5QTA/edit?usp=sharing) (credit to flywire.ai) has additional useful information that's specific to this proofreading effort!
+<a href="https://docs.google.com/document/d/1eypqJ9iI1GlWSPMTZQo9oDCLEahye6oYo_CuhS_5QTA/edit?usp=sharing" target="_blank">This cheatsheet</a> (credit to flywire.ai) has additional useful information that's specific to this proofreading effort!
 
 
 ## Additional Pages and Tools


### PR DESCRIPTION
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/10f658f4-0e15-4c8c-84f2-7c5a8d5670a0" />

A few small changes to make the getting started process a bit clearer to new users:
- buttons added to the landing page
- prompts to create an account on both the `getting started` and `about` pages
- links on the `getting started` were updated to open in new tab
- minor fix to the video player on the `getting started` page so that this renders

<img width="400" alt="image" src="https://github.com/user-attachments/assets/1ca13e97-8106-4b23-baaa-779dcf8eecae" />

