### PR TITLE
Addition of Datastack model

### DIFF
--- a/neuvue_project/neuvue/urls.py
+++ b/neuvue_project/neuvue/urls.py
@@ -31,7 +31,7 @@ from workspace.views import (
     GettingStartedView,
     SaveStateView,
     SaveOperationsView,
-    NgStatePluginsView
+    NgStatePluginsView,
 )
 from preferences.views import PreferencesView
 from dashboard.views import (
@@ -107,19 +107,31 @@ urlpatterns = [
     path("inspect/<str:task_id>", InspectTaskView.as_view(), name="inspect"),
     path("lineage/", LineageView.as_view(), name="lineage"),
     path("lineage/<str:root_id>", LineageView.as_view(), name="lineage"),
+    path(
+        "lineage/<str:datastack>/<str:root_id>", LineageView.as_view(), name="lineage"
+    ),
     path("synapse/", SynapseView.as_view(), name="synapse"),
     path("synapse/<str:root_ids>", SynapseView.as_view(), name="synapse"),
+    path(
+        "synapse/<str:datastack>/<str:root_ids>", SynapseView.as_view(), name="synapse"
+    ),
     path(
         "synapse/<str:root_ids>/<str:pre_synapses>/<str:post_synapses>/<str:cleft_layer>/<str:timestamp>",
         SynapseView.as_view(),
         name="synapse",
     ),
+    path(
+        "synapse/<str:datastack>/<str:root_ids>/<str:pre_synapses>/<str:post_synapses>/<str:cleft_layer>/<str:timestamp>",
+        SynapseView.as_view(),
+        name="synapse",
+    ),
     path("nuclei/", NucleiView.as_view(), name="nuclei"),
     path("nuclei/<str:given_ids>", NucleiView.as_view(), name="nuclei"),
+    path("nuclei/<str:datastack>/<str:given_ids>", NucleiView.as_view(), name="nuclei"),
     path("report/", ReportView.as_view(), name="report"),
     path("userNamespace/", UserNamespaceView.as_view(), name="user-namespace"),
     path("save_state", SaveStateView.as_view(), name="save-state"),
     path("save_operations", SaveOperationsView.as_view(), name="save-operations"),
     path("about", AboutView.as_view(), name="about"),
-    path("ngStatePlugin", NgStatePluginsView.as_view(), name="ng-state-plugins")
+    path("ngStatePlugin", NgStatePluginsView.as_view(), name="ng-state-plugins"),
 ]

--- a/neuvue_project/templates/lineage.html
+++ b/neuvue_project/templates/lineage.html
@@ -13,6 +13,17 @@
     <form id="mainForm" action="" method="post" onSubmit="triggerLoadingSpinner('submit-spinner')">
       {% csrf_token %}
       <div class="form-group">
+        <label class="text-white-50" for="datastackSelect">Dataset</label>
+        <select class="form-control" id="datastackSelect" name="datastack" required="true">
+          {% for ds in datastacks %}
+          <option value="{{ ds.datastack_name }}" {% if ds.datastack_name == datastack %}selected{% endif %}>
+            {{ ds.display_name }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group">
+        <label class="text-white-50" for="rootIDInput">Root ID</label>
         <input class="form-control" id="rootIDInput" placeholder="Enter Root ID" name="root_id" required="true">
         <br>
         <div class="d-flex">

--- a/neuvue_project/templates/nuclei.html
+++ b/neuvue_project/templates/nuclei.html
@@ -13,6 +13,16 @@
     <form id="mainForm" action="" method="post" onSubmit="triggerLoadingSpinner('submit-spinner')">
       {% csrf_token %}
       <div class="form-group">
+        <label class="text-white-50" for="datastackSelect">Dataset</label>
+        <select class="form-control" id="datastackSelect" name="datastack" required="true">
+          {% for ds in datastacks %}
+          <option value="{{ ds.datastack_name }}" {% if ds.datastack_name == datastack %}selected{% endif %}>
+            {{ ds.display_name }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group">
         <label class="text-white-50" for="rootIDInput">Nuclei ID and/or Seg ID (Enter ID (s) separated by commas)</label>
         <input class="form-control" id="rootIDInput" name="given_ids" required="true">
       </div>

--- a/neuvue_project/templates/synapse.html
+++ b/neuvue_project/templates/synapse.html
@@ -13,6 +13,16 @@
     <form id="mainForm" action="" method="post" onSubmit="triggerLoadingSpinner('submit-spinner')">
       {% csrf_token %}
       <div class="form-group">
+        <label class="text-white-50" for="datastackSelect">Dataset</label>
+        <select class="form-control" id="datastackSelect" name="datastack" required="true">
+          {% for ds in datastacks %}
+          <option value="{{ ds.datastack_name }}" {% if ds.datastack_name == datastack %}selected{% endif %}>
+            {{ ds.display_name }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group">
         <label class="text-white-50" for="rootIDInput">Root ID (Enter Root ID (s) separated by commas)</label>
         <input class="form-control" id="rootIDInput" name="root_ids" required="true">
       </div>

--- a/neuvue_project/workspace/admin.py
+++ b/neuvue_project/workspace/admin.py
@@ -1,8 +1,19 @@
 from django.contrib import admin
 from django.contrib.auth.models import User, Group
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
-from .models import ForcedChoiceButtonGroup, ForcedChoiceButton, Namespace, UserProfile, GroupProfile, TaskBucket, NamespaceRule, NeuroglancerPlugin
+from .models import (
+    ForcedChoiceButtonGroup,
+    ForcedChoiceButton,
+    Namespace,
+    UserProfile,
+    GroupProfile,
+    TaskBucket,
+    NamespaceRule,
+    NeuroglancerPlugin,
+    Datastack,
+)
 from .forms import NamespaceAdminForm
+
 admin.site.unregister(User)
 admin.site.unregister(Group)
 
@@ -25,23 +36,36 @@ class TaskBucketAdmin(admin.ModelAdmin):
     list_display = ("name", "description")
     search_fields = ("name",)
 
+
 @admin.register(NamespaceRule)
 class NamespaceRuleAdmin(admin.ModelAdmin):
-    list_display = ("namespace", "action", "task_bucket" )
+    list_display = ("namespace", "action", "task_bucket")
     search_fields = ("namespace__namespace", "task_bucket__name")
-    list_filter = ("namespace", "task_bucket",)
+    list_filter = (
+        "namespace",
+        "task_bucket",
+    )
+
 
 @admin.register(NeuroglancerPlugin)
 class NeuroglancerPluginAdmin(admin.ModelAdmin):
-    list_display = ("name", "description") 
+    list_display = ("name", "description")
     search_fields = ("name",)
+
 
 @admin.register(Namespace)
 class NamespaceAdmin(admin.ModelAdmin):
     form = NamespaceAdminForm
-    list_display = ("namespace", "display_name", "ng_state_plugin", "namespace_enabled")
+    list_display = (
+        "namespace",
+        "display_name",
+        "ng_state_plugin",
+        "datastack",
+        "namespace_enabled",
+    )
     search_fields = ("namespace", "display_name")
     list_filter = ("namespace_enabled",)
+
     fieldsets = [
         (
             "Namespace Information",
@@ -55,6 +79,7 @@ class NamespaceAdmin(admin.ModelAdmin):
                     "submission_method",
                     "pcg_source",
                     "img_source",
+                    "datastack",
                     "track_operation_ids",
                     "refresh_selected_root_ids",
                     "number_of_tasks_users_can_self_assign",
@@ -64,22 +89,94 @@ class NamespaceAdmin(admin.ModelAdmin):
                     "is_demo",
                 ]
             },
-        ), (
-            "Neuroglancer State Plugin",
-            {
-                "fields": [
-                    "ng_state_plugin",
-                    "plugin_params"
-                ]
-            }
-
-        ), (
+        ),
+        ("Neuroglancer State Plugin", {"fields": ["ng_state_plugin", "plugin_params"]}),
+        (
             "Default Rules",
             {
                 "fields": ["default_push_rule", "default_pull_rule"],
             },
         ),
     ]
+
+
+@admin.register(Datastack)
+class DatastackAdmin(admin.ModelAdmin):
+    list_display = (
+        "datastack_name",
+        "display_name",
+        "cave_datastack",
+        "enabled",
+        "updated_at",
+    )
+
+    search_fields = (
+        "datastack_name",
+        "display_name",
+        "cave_datastack",
+    )
+
+    list_filter = (
+        "enabled",
+        "created_at",
+        "updated_at",
+    )
+
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+    )
+
+    fieldsets = (
+        (
+            "Basic Information",
+            {
+                "fields": (
+                    "enabled",
+                    "datastack_name",
+                    "display_name",
+                    "description",
+                )
+            },
+        ),
+        (
+            "CAVE Configuration",
+            {
+                "fields": (
+                    "cave_url",
+                    "cave_datastack",
+                    "auth_token_env_var",
+                )
+            },
+        ),
+        (
+            "Data Sources",
+            {
+                "fields": (
+                    "image_source",
+                    "segmentation_source",
+                )
+            },
+        ),
+        (
+            "Viewer Configuration",
+            {
+                "fields": (
+                    "table_config",
+                    "viewer_options",
+                )
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "fields": (
+                    "created_at",
+                    "updated_at",
+                )
+            },
+        ),
+    )
 
 
 class UserProfileInline(admin.StackedInline):
@@ -94,9 +191,11 @@ class UserProfileInline(admin.StackedInline):
     #     return "None"
     # inherited_namespace_rules_display.short_description = "Inherited Namespace Rules"
 
+
 class GroupProfileInline(admin.StackedInline):
     model = GroupProfile
     filter_horizontal = ("namespace_rule",)
+
 
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):
@@ -120,7 +219,7 @@ class CustomUserAdmin(UserAdmin):
     ]
     inlines = [UserProfileInline]
 
+
 @admin.register(Group)
 class CustomGroupAdmin(GroupAdmin):
     inlines = [GroupProfileInline]
-

--- a/neuvue_project/workspace/models.py
+++ b/neuvue_project/workspace/models.py
@@ -1,3 +1,4 @@
+import os
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from colorfield.fields import ColorField
@@ -6,6 +7,64 @@ from django.contrib import admin
 from .validators import validate_submission_value, no_whitespace
 
 # Create your models here.
+
+
+class Datastack(models.Model):
+    datastack_name = models.CharField(max_length=100, unique=True, primary_key=True)
+    display_name = models.CharField(max_length=100)
+    description = models.TextField(blank=True, null=True)
+
+    cave_url = models.URLField(
+        help_text="CAVE deployment URL (e.g., https://minnie.microns-daf.com)"
+    )
+    cave_datastack = models.CharField(
+        max_length=200, help_text="Datastack name in CAVE (e.g., minnie65_phase3_v1)"
+    )
+
+    image_source = models.URLField(help_text="Image layer source (precomputed://...)")
+    segmentation_source = models.URLField(
+        help_text="Segmentation source (graphene://...)"
+    )
+
+    table_config = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="Table name mappings (synapses, nuclei, cell_classes, etc.)",
+    )
+
+    viewer_options = models.JSONField(
+        default=dict, blank=True, help_text="Viewer contrast settings and other options"
+    )
+
+    auth_token_env_var = models.CharField(
+        max_length=100,
+        default="CAVECLIENT_TOKEN",
+        help_text="Environment variable name for CAVE auth token",
+    )
+
+    enabled = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def get_table_name(self, table_type):
+        return self.table_config.get(table_type, "")
+
+    def get_auth_token(self):
+        return os.environ.get(
+            self.auth_token_env_var, os.environ.get("CAVECLIENT_TOKEN")
+        )
+
+    def get_viewer_options(self):
+        if self.viewer_options:
+            return self.viewer_options
+        return {"contrast": {"black": 0, "white": 1}}
+
+    class Meta:
+        verbose_name = "Datastack"
+        verbose_name_plural = "Datastacks"
+
+    def __str__(self):
+        return f"{self.display_name} ({self.datastack_name})"
 
 
 class NeuroglancerLinkType(models.TextChoices):
@@ -100,8 +159,9 @@ class PcgChoices(models.TextChoices):
         "https://minnie.microns-daf.com/segmentation/table/pinky_v2_microns_sandbox",
         _("Pinky"),
     )
-    MINNIE_PUBLIC = ("https://minnie.microns-daf.com/segmentation/table/minnie65_public",
-        _("Minnie65 Public (read-only)")
+    MINNIE_PUBLIC = (
+        "https://minnie.microns-daf.com/segmentation/table/minnie65_public",
+        _("Minnie65 Public (read-only)"),
     )
     OTHER = "N/A", _("Other")
 
@@ -117,6 +177,7 @@ class ImageChoices(models.TextChoices):
     )
     OTHER = "N/A", _("Other")
 
+
 class TaskBucketActions(models.TextChoices):
     PUSH = (
         "push",
@@ -127,10 +188,12 @@ class TaskBucketActions(models.TextChoices):
         _("Pull tasks from"),
     )
 
+
 class NeuroglancerPlugin(models.Model):
     """
     A model to represent a Neuroglancer plugin.
     """
+
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField(blank=True, null=True)
     default_plugin_params = models.JSONField(blank=True, null=True)
@@ -138,17 +201,20 @@ class NeuroglancerPlugin(models.Model):
     def __str__(self):
         return self.name
 
+
 class TaskBucket(models.Model):
     name = models.CharField(max_length=50, unique=True)
     description = models.TextField(blank=True, null=True)
     bucket_assignee = models.CharField(
-        max_length=50, 
-        unique=True, 
+        max_length=50,
+        unique=True,
         help_text="Assignee string to in the queue for this task bucket",
-        validators=[no_whitespace]
+        validators=[no_whitespace],
     )
+
     def __str__(self):
         return self.name
+
 
 class Namespace(models.Model):
     namespace_enabled = models.BooleanField(default=True)
@@ -186,15 +252,18 @@ class Namespace(models.Model):
     decrement_priority = models.IntegerField(
         default=100, verbose_name="When skipped, decrement priority by"
     )
-    is_demo = models.BooleanField(default=False, verbose_name="Demonstration only? (Submitting does not patch task)")
-    
+    is_demo = models.BooleanField(
+        default=False,
+        verbose_name="Demonstration only? (Submitting does not patch task)",
+    )
+
     ng_state_plugin = models.ForeignKey(
         NeuroglancerPlugin,
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
         help_text="Neuroglancer plugin to use for this namespace. If not set, no plugin will be used.",
-        related_name="ng_state_plugin"
+        related_name="ng_state_plugin",
     )
 
     default_push_rule = models.ForeignKey(
@@ -213,19 +282,29 @@ class Namespace(models.Model):
         blank=True,
         help_text="Select the default pull rule for this namespace. Must be set after the namespace is created.",
     )
-    
+
     plugin_params = models.JSONField(
         blank=True,
         null=True,
-        help_text=("Override the default plugin parameters (specified in NeuroglancerPlugin) "
-                   "with namespace-specific values. Provided values will update/override the defaults."),
+        help_text=(
+            "Override the default plugin parameters (specified in NeuroglancerPlugin) "
+            "with namespace-specific values. Provided values will update/override the defaults."
+        ),
+    )
+
+    datastack = models.ForeignKey(
+        Datastack,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        help_text="Optional: Override default datastack for this namespace. If not set, default datastack (minnie65) is used.",
     )
 
     def get_effective_plugin_params(self):
         """
-        Return the effective plugin parameters for this namespace by merging the default plugin parameters 
+        Return the effective plugin parameters for this namespace by merging the default plugin parameters
         with any namespace-specific overrides. Namespace overrides take precedence.
-        
+
         Returns:
             dict: The merged plugin parameters.
         """
@@ -240,7 +319,7 @@ class Namespace(models.Model):
             effective_params.update(self.plugin_params)
 
         return effective_params
-    
+
     def save(self, *args, **kwargs):
         """
         Optionally, when saving a Namespace, if plugin_params is not defined,
@@ -257,11 +336,14 @@ class Namespace(models.Model):
 
 class NamespaceRule(models.Model):
     namespace = models.ForeignKey(Namespace, on_delete=models.CASCADE)
-    action = models.CharField(max_length=10, 
-                              choices=TaskBucketActions.choices, 
-                              default=TaskBucketActions.PULL, 
-                              help_text="Determines if this rule provides a source or sink for tasks in the queue")
+    action = models.CharField(
+        max_length=10,
+        choices=TaskBucketActions.choices,
+        default=TaskBucketActions.PULL,
+        help_text="Determines if this rule provides a source or sink for tasks in the queue",
+    )
     task_bucket = models.ForeignKey(TaskBucket, on_delete=models.CASCADE)
+
     class Meta:
         unique_together = ("namespace", "action", "task_bucket")
 
@@ -273,7 +355,7 @@ class NamespaceRule(models.Model):
 class UserProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     namespace_rule = models.ManyToManyField(NamespaceRule, blank=True)
-    
+
     # @property
     # def inherited_namespace_rules(self):
     #     """Get all namespace rules inherited from the user's groups."""
@@ -281,6 +363,7 @@ class UserProfile(models.Model):
     #         groupprofile__group__in=self.user.groups.all()
     #     )
     #     return group_rules.distinct()
+
 
 # Janky way to extend the default Group model
 class GroupProfile(models.Model):

--- a/neuvue_project/workspace/neuroglancer.py
+++ b/neuvue_project/workspace/neuroglancer.py
@@ -31,6 +31,7 @@ from .models import (
     PcgChoices,
     ImageChoices,
     NeuroglancerHost,
+    Datastack,
 )
 
 
@@ -77,43 +78,55 @@ def get_df_from_static(cave_client, table_name):
         raise Exception(f"Table {table_name} unavailable.")
 
 
-def create_base_state(seg_ids, coordinate, namespace=None):
+def create_base_state(seg_ids, coordinate, namespace=None, datastack=None):
     """Generates a base state containing imagery and segmentation layers.
 
     Args:
         seg_ids (list): seg_ids to select in the view
         coordinate (tuple|list): collection of three integer voxel coordinates, XYZ order.
         namespace (str): task namespace
+        datastack (str): datastack name (e.g., minnie65_phase3_v1)
     Returns:
         StateBuilder: Base State
     """
 
-    # Create ImageLayerConfig
-    if namespace:
+    # Determine image and segmentation sources from datastack or namespace
+
+    if datastack:
+        try:
+            ds = Datastack.objects.get(datastack_name=datastack)
+            img_source = "precomputed://" + ds.image_source
+            seg_source = "graphene://" + ds.segmentation_source
+            viewer_opts = ds.get_viewer_options()
+            black = viewer_opts.get("contrast", {}).get("black", 0)
+            white = viewer_opts.get("contrast", {}).get("white", 1)
+        except Datastack.DoesNotExist:
+            img_source = "precomputed://" + ImageChoices.MINNIE
+            seg_source = "graphene://" + PcgChoices.MINNIE
+            black = 0
+            white = 1
+    elif namespace:
         img_source = (
             "precomputed://" + Namespace.objects.get(namespace=namespace).img_source
         )
+        seg_source = (
+            "graphene://" + Namespace.objects.get(namespace=namespace).pcg_source
+        )
+        try:
+            black = settings.DATASET_VIEWER_OPTIONS[img_source]["contrast"]["black"]
+            white = settings.DATASET_VIEWER_OPTIONS[img_source]["contrast"]["white"]
+        except KeyError:
+            black = 0
+            white = 1
     else:
         img_source = "precomputed://" + ImageChoices.MINNIE
-
-    try:
-        black = settings.DATASET_VIEWER_OPTIONS[img_source]["contrast"]["black"]
-        white = settings.DATASET_VIEWER_OPTIONS[img_source]["contrast"]["white"]
-    except KeyError:
+        seg_source = "graphene://" + PcgChoices.MINNIE
         black = 0
         white = 1
 
     img_layer = ImageLayerConfig(
         name="em", source=img_source, contrast_controls=True, black=black, white=white
     )
-
-    # Create SegmentationLayerConfig
-    if namespace:
-        seg_source = (
-            "graphene://" + Namespace.objects.get(namespace=namespace).pcg_source
-        )
-    else:
-        seg_source = "graphene://" + PcgChoices.MINNIE
 
     segmentation_view_options = {"alpha_selected": 0.6, "alpha_3d": 0.3}
     seg_layer = SegmentationLayerConfig(
@@ -300,7 +313,7 @@ def get_from_state_server(url: str):
     }
     if "bossdb-neuvue-datalake" not in url:
         headers["Authorization"] = f"Bearer {os.environ['CAVECLIENT_TOKEN']}"
-    
+
     resp = requests.get(url, headers=headers)
     if resp.status_code != 200:
         raise Exception("GET Unsuccessful")
@@ -310,7 +323,7 @@ def get_from_state_server(url: str):
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
-def post_to_state_server(state: str, public = False):
+def post_to_state_server(state: str, public=False):
     """Posts JSON string to state server
 
     Args:
@@ -324,17 +337,18 @@ def post_to_state_server(state: str, public = False):
         "content-type": "application/json",
     }
     if public:
-        resp = requests.post(settings.PUBLIC_JSON_STATE_SERVER, data=state, headers=headers)
+        resp = requests.post(
+            settings.PUBLIC_JSON_STATE_SERVER, data=state, headers=headers
+        )
         if resp.status_code != 200:
             raise Exception("POST Unsuccessful")
-        return str(resp.json()['url'])
+        return str(resp.json()["url"])
     else:
         headers["Authorization"] = f"Bearer {os.environ['CAVECLIENT_TOKEN']}"
         resp = requests.post(settings.JSON_STATE_SERVER, data=state, headers=headers)
         if resp.status_code != 200:
             raise Exception("POST Unsuccessful")
         return str(resp.json())
-
 
 
 def get_from_json(raw_state: str):
@@ -452,18 +466,23 @@ def _get_nx_graph_image(nx_graph):
     return networkx_to_graphViz(nx_graph)
 
 
-def construct_lineage_state_and_graph(root_id: str):
+def construct_lineage_state_and_graph(root_id: str, datastack: str = None):
     """Construct state for the lineage viewer.
 
     Args:
         root_id (str): segment root id
+        datastack (str): datastack name
 
     Returns:
         string: json-formatted state
     """
+    if datastack is None:
+        datastack = "minnie65_phase3_v1"
+
     root_id = root_id.strip()
+    ds = Datastack.objects.get(datastack_name=datastack)
     cave_client = CAVEclient(
-        "minnie65_phase3_v1", auth_token=os.environ["CAVECLIENT_TOKEN"]
+        ds.cave_datastack, server_address=ds.cave_url, auth_token=ds.get_auth_token()
     )
 
     # Lineage graph gives you the nodes and edges of a root IDs history
@@ -477,7 +496,7 @@ def construct_lineage_state_and_graph(root_id: str):
     root_ids = list(root_ids)
 
     position, root_ids_with_center = _get_soma_center(root_ids, cave_client)
-    base_state = create_base_state(root_ids_with_center, position)
+    base_state = create_base_state(root_ids_with_center, position, datastack=datastack)
 
     # For the rest of the IDs, we can add them to the seg layer as unselected.
     base_state_dict = base_state.render_state(return_as="dict")
@@ -741,7 +760,7 @@ def apply_state_config(state: str, username: str):
     return json.dumps(cdict)
 
 
-def construct_synapse_state(root_ids: List, flags: dict = None):
+def construct_synapse_state(root_ids: List, flags: dict = None, datastack: str = None):
     """Construct state for the synapse viewer.
 
     Args:
@@ -751,15 +770,23 @@ def construct_synapse_state(root_ids: List, flags: dict = None):
             - post_synapses
             - cleft_layer
             - timestamp
+        datastack (str): datastack name
 
     Returns:
         string: json-formatted state
         dict: synapse stats
     """
+    if datastack is None:
+        datastack = "minnie85_phase3_v1"
+
+    ds = Datastack.objects.get(datstack_name=datastack)
     cave_client = CAVEclient(
-        "minnie65_phase3_v1", auth_token=os.environ["CAVECLIENT_TOKEN"]
+        ds.cave_datastack, server_address=ds.cave_url, auth_token=ds.get_auth_token()
     )
     int_root_ids = [int(x) for x in root_ids]
+
+    # Get synapse table name from datastack config
+    synapse_table = ds.get_table_name("syanpses") or settings.SYNAPSE_TABLE
 
     # Error checking
     if flags["pre_synapses"] != "True" and flags["post_synapses"] != "True":
@@ -772,7 +799,7 @@ def construct_synapse_state(root_ids: List, flags: dict = None):
         if flags["timestamp"] != "None":
             try:
                 pre_synapses = cave_client.materialize.query_table(
-                    settings.SYNAPSE_TABLE,
+                    synapse_table,
                     filter_in_dict={"pre_pt_root_id": int_root_ids},
                     select_columns=[
                         "ctr_pt_position",
@@ -785,7 +812,7 @@ def construct_synapse_state(root_ids: List, flags: dict = None):
                 raise Exception(f"Root ID {index} not found for this timestamp")
         else:
             pre_synapses = cave_client.materialize.query_table(
-                settings.SYNAPSE_TABLE,
+                synapse_table,
                 filter_in_dict={"pre_pt_root_id": int_root_ids},
                 select_columns=["ctr_pt_position", "pre_pt_root_id", "post_pt_root_id"],
             )
@@ -804,7 +831,7 @@ def construct_synapse_state(root_ids: List, flags: dict = None):
         if flags["timestamp"] != "None":
             try:
                 post_synapses = cave_client.materialize.query_table(
-                    settings.SYNAPSE_TABLE,
+                    synapse_table,
                     filter_in_dict={"post_pt_root_id": int_root_ids},
                     select_columns=[
                         "ctr_pt_position",
@@ -832,7 +859,7 @@ def construct_synapse_state(root_ids: List, flags: dict = None):
         position = np.random.choice(post_synapses["ctr_pt_position"].to_numpy())
 
     data_list = [None]
-    base_state = create_base_state(root_ids, position)
+    base_state = create_base_state(root_ids, position, datastack=datastack)
 
     # Random color generation
     r = lambda: random.randint(0, 255)
@@ -952,22 +979,28 @@ def construct_synapse_state(root_ids: List, flags: dict = None):
     return json.dumps(state_dict, default=lambda x: [str(y) for y in x]), synapse_stats
 
 
-def construct_nuclei_state(given_ids: List):
+def construct_nuclei_state(given_ids: List, datastack: str = None):
     """Construct state for the synapse viewer.
 
     Args:
         given_ids (list): nuclei and/or pt_root_ids
+        datastack (str): datastack name
 
     Returns:
         string: json-formatted state
         dict: synapse stats
     """
+    if dataset is None:
+        datastack = "minnie65_phase3_v1"
+
     given_ids = [int(x) for x in given_ids]
+    ds = Datastack.objects.get(datastack_name=datastack)
     cave_client = CAVEclient(
-        "minnie65_phase3_v1", auth_token=os.environ["CAVECLIENT_TOKEN"]
+        ds.cave_datastack, server_address=ds.cave_url, auth_token=ds.get_auth_token()
     )
 
-    soma_df = get_df_from_static(cave_client, settings.NEURON_TABLE)
+    nuclei_table = ds.get_table_name("nuclei") or settings.NEURON_TABLE
+    soma_df = get_df_from_static(cave_client, nuclei_table)
     soma_df = soma_df[
         (soma_df.id.isin(given_ids)) | (soma_df.pt_root_id.isin(given_ids))
     ]
@@ -988,7 +1021,7 @@ def construct_nuclei_state(given_ids: List):
         raise Exception("ID is outdated or does not exist.")
 
     data_list = [None]
-    base_state = create_base_state(root_ids, position)
+    base_state = create_base_state(root_ids, position, datastack=datastack)
 
     # Random color generation
     r = lambda: random.randint(0, 255)
@@ -1051,17 +1084,21 @@ def construct_nuclei_state(given_ids: List):
     return json.dumps(state_dict), cell_type_table, formatted_not_found_ids
 
 
-def refresh_ids(ng_state: str, namespace: str):
-    namespace = Namespace.objects.get(namespace=namespace)
-    if not namespace.refresh_selected_root_ids:
-        return ng_state
+def refresh_ids(ng_state: str, namespace: str = None, datastack: str = None):
+    if datastack is None and namespace:
+        ns = Namespace.objects.get(namespace=namespace)
+        if not ns.refresh_selected_root_ids:
+            return ng_state
+        # Use namespace's datastack if available, otherwise default
+        datastack = ns.datastack.datastack_name if ns.datastack else None
 
-    if namespace.pcg_source == PcgChoices.PINKY:
-        return ng_state
-    else:
-        cave_client = CAVEclient(
-            "minnie65_phase3_v1", auth_token=os.environ["CAVECLIENT_TOKEN"]
-        )
+    if datastack is None:
+        datastack = "minnie65_phase3_v1"
+
+    ds = Datastack.objects.get(datastack_name=datastack)
+    cave_client = CAVEclient(
+        ds.cave_datastack, server_address=ds.cave_url, auth_token=ds.get_auth_token()
+    )
 
     state = json.loads(ng_state)
     for layer in state["layers"]:

--- a/neuvue_project/workspace/views/tools.py
+++ b/neuvue_project/workspace/views/tools.py
@@ -5,7 +5,7 @@ from django.views.generic.base import View
 from django.conf import settings
 from neuvue.client import client
 
-from ..models import Namespace, NeuroglancerHost
+from ..models import Namespace, NeuroglancerHost, Datastack
 from ..neuroglancer import (
     construct_proofreading_state,
     construct_lineage_state_and_graph,
@@ -22,6 +22,26 @@ from ..utils import is_url, is_json, is_authorized
 logging.basicConfig(level=logging.INFO)
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
+
+
+class DatastackMixin:
+    """Mixin to handle datastack selection and backward compatibility for URLs without datastack parameter"""
+
+    def get_datastack(self, kwargs):
+        """Get datastack from kwargs, default to first enabled datastack if not provided"""
+        datastack = kwargs.get("datastack")
+        if datastack is None:
+            ds = Datastack.objects.filter(enabled=True).first()
+            return ds.datastack_name if ds else "minnie65_phase3_v1"
+        return datastack
+
+    def get_datastack_object(self, datastack_name):
+        """Get Datastack object, with fallback to default if not found"""
+        try:
+            return Datastack.objects.get(datastack_name=datastack_name, enabled=True)
+        except Datastack.DoesNotExist:
+            ds = Datastack.objects.filter(enabled=True).first()
+            return ds if ds else None
 
 
 class InspectTaskView(View):
@@ -129,24 +149,41 @@ class InspectTaskView(View):
         return redirect(reverse("inspect", kwargs={"task_id": task_id}))
 
 
-class LineageView(View):
-    def get(self, request, root_id=None, *args, **kwargs):
+class LineageView(DatastackMixin, View):
+    def get(self, request, datastack=None, root_id=None, *args, **kwargs):
         if not request.user.is_staff:
             return redirect(reverse("index"))
+
+        # Handle backward compatibility: redirect old URLs without datastack to new format
+        if datastack is None and root_id is not None:
+            ds = self.get_datastack({"datastack": None})
+            return redirect(
+                reverse("lineage", kwargs={"datastack": ds, "root_id": root_id})
+            )
 
         if root_id in settings.STATIC_NG_FILES:
             return redirect(
                 f"/static/workspace/{root_id}", content_type="application/javascript"
             )
 
-        context = {"root_id": root_id, "ng_state": None, "graph": None, "error": None}
+        datastack_name = self.get_datastack({"datastack": datastack})
+        ds_obj = self.get_datastack_object(datastack_name)
+
+        context = {
+            "root_id": root_id,
+            "ng_state": None,
+            "graph": None,
+            "error": None,
+            "datastack": datastack_name,
+            "datastacks": Datastack.objects.filter(enabled=True),
+        }
 
         if root_id is None:
             return render(request, "lineage.html", context)
 
         try:
             context["ng_state"], context["graph"] = construct_lineage_state_and_graph(
-                root_id
+                root_id, datastack=datastack_name
             )
         except Exception as e:
             context["error"] = e
@@ -154,14 +191,18 @@ class LineageView(View):
         return render(request, "lineage.html", context)
 
     def post(self, request, *args, **kwargs):
+        datastack = request.POST.get("datastack")
         root_id = request.POST.get("root_id")
-        return redirect(reverse("lineage", kwargs={"root_id": root_id}))
+        return redirect(
+            reverse("lineage", kwargs={"datastack": datastack, "root_id": root_id})
+        )
 
 
-class SynapseView(View):
+class SynapseView(DatastackMixin, View):
     def get(
         self,
         request,
+        datastack=None,
         root_ids=None,
         pre_synapses=None,
         post_synapses=None,
@@ -174,6 +215,23 @@ class SynapseView(View):
             logging.warning(f"Unauthorized requests from {request.user}.")
             return redirect(reverse("index"))
 
+        # Handle backward compatibility: redirect old URLs without datastack to new format
+        if datastack is None and root_ids is not None:
+            ds = self.get_datastack({"datastack": None})
+            return redirect(
+                reverse(
+                    "synapse",
+                    kwargs={
+                        "datastack": ds,
+                        "root_ids": root_ids,
+                        "pre_synapses": pre_synapses,
+                        "post_synapses": post_synapses,
+                        "cleft_layer": cleft_layer,
+                        "timestamp": timestamp,
+                    },
+                )
+            )
+
         if root_ids in settings.STATIC_NG_FILES:
             return redirect(
                 f"/static/workspace/{root_ids}", content_type="application/javascript"
@@ -182,6 +240,9 @@ class SynapseView(View):
             return redirect(
                 f"/static/workspace/{timestamp}", content_type="application/javascript"
             )
+
+        datastack_name = self.get_datastack({"datastack": datastack})
+        ds_obj = self.get_datastack_object(datastack_name)
 
         context = {
             "root_ids": None,
@@ -192,6 +253,8 @@ class SynapseView(View):
             "ng_state": None,
             "synapse_stats": None,
             "error": None,
+            "datastack": datastack_name,
+            "datastacks": Datastack.objects.filter(enabled=True),
         }
 
         if root_ids is None:
@@ -211,7 +274,7 @@ class SynapseView(View):
             context["cleft_layer"] = cleft_layer
             context["timestamp"] = timestamp
             context["ng_state"], context["synapse_stats"] = construct_synapse_state(
-                root_ids=root_ids, flags=flags
+                root_ids=root_ids, flags=flags, datastack=datastack_name
             )
         except Exception as e:
             print(e)
@@ -220,6 +283,7 @@ class SynapseView(View):
         return render(request, "synapse.html", context)
 
     def post(self, request, *args, **kwargs):
+        datastack = request.POST.get("datastack")
         root_ids = request.POST.get("root_ids")
         pre_synapses = request.POST.get("pre_synapses")
         post_synapses = request.POST.get("post_synapses")
@@ -232,6 +296,7 @@ class SynapseView(View):
             reverse(
                 "synapse",
                 kwargs={
+                    "datastack": datastack,
                     "root_ids": root_ids,
                     "pre_synapses": pre_synapses,
                     "post_synapses": post_synapses,
@@ -242,18 +307,33 @@ class SynapseView(View):
         )
 
 
-class NucleiView(View):
-    def get(self, request, given_ids=None, *args, **kwargs):
+class NucleiView(DatastackMixin, View):
+    def get(self, request, datastack=None, given_ids=None, *args, **kwargs):
         if not is_authorized(request.user):
             logging.warning(f"Unauthorized requests from {request.user}.")
             return redirect(reverse("index"))
+
+        # Handle backward compatibility: redirect old URLs without datastack to new format
+        if datastack is None and given_ids is not None:
+            ds = self.get_datastack({"datastack": None})
+            return redirect(
+                reverse("nuclei", kwargs={"datastack": ds, "given_ids": given_ids})
+            )
 
         if given_ids in settings.STATIC_NG_FILES:
             return redirect(
                 f"/static/workspace/{given_ids}", content_type="application/javascript"
             )
 
-        context = {"given_ids": None, "error": None}
+        datastack_name = self.get_datastack({"datastack": datastack})
+        ds_obj = self.get_datastack_object(datastack_name)
+
+        context = {
+            "given_ids": None,
+            "error": None,
+            "datastack": datastack_name,
+            "datastacks": Datastack.objects.filter(enabled=True),
+        }
 
         if given_ids is None:
             return render(request, "nuclei.html", context)
@@ -266,19 +346,21 @@ class NucleiView(View):
                 context["ng_state"],
                 context["cell_types"],
                 context["ids_not_found"],
-            ) = construct_nuclei_state(given_ids=given_ids)
+            ) = construct_nuclei_state(given_ids=given_ids, datastack=datastack_name)
         except Exception as e:
             context["error"] = e
 
         return render(request, "nuclei.html", context)
 
     def post(self, request, *args, **kwargs):
+        datastack = request.POST.get("datastack")
         given_ids = request.POST.get("given_ids")
 
         return redirect(
             reverse(
                 "nuclei",
                 kwargs={
+                    "datastack": datastack,
                     "given_ids": given_ids,
                 },
             )


### PR DESCRIPTION
Creation of `Datastack` model so that the backend for namespaces and lineage, synapse, and nuclei viewers. Back compatibility is set to still default to _minnie65_ settings, though new ones can be added and assigned. 

**Frontend** changes to:
- lineage, synapse, and nuclei html to add drop-down menus to select from `Datastack` objects
- Admin dashboard to show `Datastack` object and foreign key on `Namespace` to define `Datastack` (again, fallback is _minnie65_, so all existing namespaces do not need to be updated)

**Backend** changes to:
- models to create `Datastack` object
- neuroglancer + tools to separate from _minnie65_ strict definition, instead pull values from data stack objects (or _minnie65_ fallback)
- urls to accommodate new dataset argument in pathway for lineage, synapse, and nuclei viewer