### PR TITLE
Minor UI changes 

### DIFF
--- a/neuvue_project/templates/about.html
+++ b/neuvue_project/templates/about.html
@@ -61,7 +61,7 @@
         <h2>Publications</h2>
 
         <p>
-          <a href="https://www.biorxiv.org/content/10.1101/2022.07.18.500521v1" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.biorxiv.org/content/10.1101/2022.07.18.500521v2" target="_blank" rel="noopener noreferrer">
             NeuVue: A Framework and Workflows for High-Throughput Electron Microscopy Connectomics Proofreading
           </a>
         </p>
@@ -86,12 +86,6 @@
             <img src="{% static 'images/University-of-Princeton-Logo.png' %}" alt="Princeton University">
           </a>
         </div>
-
-        <h2>Contact Us</h2>
-
-        <p>
-          Reach out at <a href="mailto:info@bossdb.org">info@bossdb.org</a> with questions or if you are interested in collaborating with us.
-        </p>
       </div>
     </article>
   </div>

--- a/neuvue_project/templates/base.html
+++ b/neuvue_project/templates/base.html
@@ -54,13 +54,13 @@
 
             {% endif %}
 
-            {% if request.user|in_group:"AuthorizedUsers"%}
             <li class="nav-item">
               <a class="nav-link" href="{% url "about" %}">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="{% url "getting-started" %}">Getting Started</a>
             </li>
+            {% if request.user|in_group:"AuthorizedUsers"%}
             <li class="nav-item">
               <a class="nav-link" href="{% url "inspect" %}">Inspect Task</a>
             </li>
@@ -110,7 +110,9 @@
 
     <footer class="nv-footer">
       <div class="nv-footer-inner">
-        <a href="mailto:info@bossdb.org">Contact info@bossdb.org</a>
+        <div>
+          Have questions or are interested in collaborating? Email us at <a href="mailto:neuvue@bossdb.org">neuvue@bossdb.org</a>.
+        </div>
         <span>Version {{ neuvue_app_version }}</span>
       </div>
     </footer>

--- a/neuvue_project/templates/tasks.html
+++ b/neuvue_project/templates/tasks.html
@@ -242,12 +242,6 @@
             </div>
           </div>
         </article>
-
-        {% if not data.settings.is_authorized %}
-          <div class="nv-empty nv-contact-note">
-            Have questions or are interested in collaborating? Email us at <a href="mailto:neuvue@bossdb.org">neuvue@bossdb.org</a>.
-          </div>
-        {% endif %}
       </section>
     </div>
 


### PR DESCRIPTION
3 small changes to the UI refresh:

- update neuvue paper link to the v2
- two different contact emails listed -> consolidated to the bottom banner with neuvue@bossdb.org (previously a mix of info@bossdb.org and neuvue@bossdb.org)
- adjusted accessibility of _About_ and _Getting Started_ tabs to no-restrictions. Previously accessible only through landing page if you were a non-authenticated user.